### PR TITLE
Fix crash on epub file creation due to book title containing reserved…

### DIFF
--- a/lib/readmoo_dl/downloader.rb
+++ b/lib/readmoo_dl/downloader.rb
@@ -96,6 +96,9 @@ module ReadmooDL
       files = book[:files]
       filename = "#{title}.epub"
 
+      # Replace reserved characters that shouldn't be used in file names
+      filename = filename.gsub(/[\/\\:\*\?\"\<\>\|]/, '_')
+
       Zip::File.open(filename, Zip::File::CREATE) do |zipfile|
         files.each do |file|
           zipfile.get_output_stream(Pathname.new(file.path).cleanpath) { |zip| zip.write(file.content) }


### PR DESCRIPTION
… characters (such as : or /) and replace with an underscore

Example to reproduce issue: id 210099563000101